### PR TITLE
Fixing to passing the parameters for safe_asterisk

### DIFF
--- a/contrib/init.d/rc.redhat.asterisk
+++ b/contrib/init.d/rc.redhat.asterisk
@@ -115,10 +115,10 @@ start() {
 	fi
 	if [ "x$COLOR" = "xyes" ]; then
 		export TERM=linux
-		daemon sh -c "$DAEMON $ASTARGS -c" >/dev/null </dev/null 2>&1 &
-	else
-		daemon $DAEMON $ASTARGS
 	fi
+	
+	daemon $DAEMON $ASTARGS
+	
 	RETVAL=$?
 	[ $RETVAL -eq 0 ] && touch /var/lock/subsys/asterisk
 	echo


### PR DESCRIPTION
The fix allow passing the parameters like -U and -G for execution an asterisk and enable color on cli.
